### PR TITLE
Add docker metrics to docker role

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,3 +19,6 @@ docker_service_enabled: yes
 docker_users: [
 # "username"
 ]
+
+docker_metrics_enabled: no
+docker_metrics_port: 9323

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -63,6 +63,16 @@
         (docker_startup_options != "")
   tags: ["docker","configuration"]
 
+- name: Configure docker metrics publishing
+  template:
+    src: docker-daemon.json.j2
+    dest: /etc/docker/daemon.json
+  become: yes
+  notify:
+    - restart docker
+  when: docker_metrics_enabled
+  tags: ["docker","configuration"]
+
 - name: Create docker group
   group:
     name: "{{ docker_group }}"
@@ -94,3 +104,5 @@
   become: yes
   register: start_stop_docker
   tags: ["docker","service"]
+
+- meta: flush_handlers

--- a/templates/docker-daemon.json.j2
+++ b/templates/docker-daemon.json.j2
@@ -1,0 +1,4 @@
+{
+    "metrics-addr" : "127.0.0.1:{{ docker_metrics_port }}",
+    "experimental" : true
+}


### PR DESCRIPTION
Adds a task that installs a file to /etc/docker/daemon.json which enabled metrics

**NOTE: Currently overwrites a file that might already be there**